### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,28 @@ This contains a game called "Tic Tac Toe", also known as "Naughts and Crosses".
 
 ## Setup
 
-(Instructions Here)
+Install dependencies for this revolutionary software using the conda package manager.
+
+```bash
+#confirm that you're in the same directory as the environment info file
+ls environment.yaml
+
+#create the environment with the given path using the provided environment.yaml file
+conda env create -p ./venv -f environment.yaml
+
+#activate the newly created environment
+conda activate ./venv
+
+#confirm dependencies installed correctly by testing for python, output should end in `venv/bin/python3.12`
+which python3.12
+```
 
 ## Running the App
 
 Run the app directly with a 
 
 ```bash
-python tictactoe.py
+python3.12 tictactoe.py
 ```
 
 ## Exercise

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,32 @@
+name: /home/katerina/GitTest/tictactoe/venv
+channels:
+  - conda-forge
+  - bioconda
+  - liulab-dfci
+dependencies:
+  - _libgcc_mutex=0.1=conda_forge
+  - _openmp_mutex=4.5=2_gnu
+  - bzip2=1.0.8=h4bc722e_7
+  - ca-certificates=2025.1.31=hbcca054_0
+  - ld_impl_linux-64=2.43=h712a8e2_4
+  - libexpat=2.6.4=h5888daf_0
+  - libffi=3.4.6=h2dba641_0
+  - libgcc=14.2.0=h767d61c_2
+  - libgcc-ng=14.2.0=h69a702a_2
+  - libgomp=14.2.0=h767d61c_2
+  - liblzma=5.6.4=hb9d3cd8_0
+  - libnsl=2.0.1=hd590300_0
+  - libsqlite=3.49.1=hee588c1_1
+  - libuuid=2.38.1=h0b41bf4_0
+  - libxcrypt=4.4.36=hd590300_1
+  - libzlib=1.3.1=hb9d3cd8_2
+  - ncurses=6.5=h2d0b736_3
+  - openssl=3.4.1=h7b32b05_0
+  - pip=25.0.1=pyh8b19718_0
+  - python=3.12.9=h9e4cc4f_0_cpython
+  - readline=8.2=h8c095d6_2
+  - setuptools=75.8.0=pyhff2d567_0
+  - tk=8.6.13=noxft_h4845f30_101
+  - tzdata=2025a=h78e105d_0
+  - wheel=0.45.1=pyhd8ed1ab_1
+prefix: /home/katerina/GitTest/tictactoe/venv


### PR DESCRIPTION
`python tictactoe.py` command did not work for me. (Missing module: pyxel. Running `pip install pyxel` kept installing it into my local environment, not the activated environment.)
Changed it to `python3.12 tictactoe.py` and it works.